### PR TITLE
Prefab spawning

### DIFF
--- a/Assets/Resources/GamePfs.meta
+++ b/Assets/Resources/GamePfs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d90993d6c51ab3b47a9209471cfa5287
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/GamePfs/Test.prefab
+++ b/Assets/Resources/GamePfs/Test.prefab
@@ -1,0 +1,221 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4857801152846723944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5063525412723798145}
+  - component: {fileID: 1218771060367358620}
+  m_Layer: 23
+  m_Name: TrunkTop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!4 &5063525412723798145
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4857801152846723944}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.14, y: 30.8, z: 0.1}
+  m_LocalScale: {x: 1.6201726, y: 36.849525, z: 1.3529273}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4490656172688148918}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &1218771060367358620
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4857801152846723944}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.57
+  m_Height: 1.56
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &6639864313185290796
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8051156747973575575}
+  - component: {fileID: 4137388594338085546}
+  m_Layer: 23
+  m_Name: TrunkBottom
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!4 &8051156747973575575
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6639864313185290796}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.14, y: 16.5, z: 0.1}
+  m_LocalScale: {x: 1.6201726, y: 42.698658, z: 1.3529273}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4490656172688148918}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!136 &4137388594338085546
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6639864313185290796}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.87
+  m_Height: 0.85
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &8706896050500350311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4490656172688148918}
+  - component: {fileID: 5558992567230421635}
+  - component: {fileID: 5813552690050065220}
+  - component: {fileID: 5641700898046271422}
+  m_Layer: 23
+  m_Name: Test
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!4 &4490656172688148918
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8706896050500350311}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000037748947, y: 0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.76, y: 0, z: -21.62}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8051156747973575575}
+  - {fileID: 5063525412723798145}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &5558992567230421635
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8706896050500350311}
+  m_Mesh: {fileID: -8967784782761240475, guid: ed53f210c854d464e8fa499675b495c8, type: 3}
+--- !u!23 &5813552690050065220
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8706896050500350311}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 2ceb4f702fa70c140b96a58c57c04578, type: 2}
+  - {fileID: 2100000, guid: 2433ac5cb99209640b3b571fbc1c49fe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &5641700898046271422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8706896050500350311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 1
+  OwnershipTransfer: 1
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0

--- a/Assets/Resources/GamePfs/Test.prefab.meta
+++ b/Assets/Resources/GamePfs/Test.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 31dcf6f8be1283e468d4047cb521925c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManagers/ChatManager.cs
+++ b/Assets/Scripts/GameManagers/ChatManager.cs
@@ -322,7 +322,7 @@ namespace GameManagers
                 if (args.Length != 6)
                 {
                     AddLine("Invalid arguments passed! Correct usage: /spawn [PrefabName][Tag][Position][Rotation][Scale]", ChatTextColor.Error);
-                    AddLine("Example usage: /spawn Test test_prefab_1 (-16,2,-500) (1,1,1,1) (1,1,1)", ChatTextColor.Error);
+                    AddLine("Example usage: /spawn Test test_prefab_1 (-16,2,-500) (0,0,0,1) (1,1,1)", ChatTextColor.Error);
                     return;
                 }
 

--- a/Assets/Scripts/GameManagers/ChatManager.cs
+++ b/Assets/Scripts/GameManagers/ChatManager.cs
@@ -16,6 +16,7 @@ using System.Reflection;
 using System.Linq;
 using Map;
 using System.Collections;
+using NUnit.Framework.Constraints;
 
 
 namespace GameManagers
@@ -293,6 +294,8 @@ namespace GameManagers
             }
         }
 
+        #region Expedition Mod Commands
+
         [CommandAttribute("load", "/load [SCENE NAME]: Loads a custom scene for expeditions")]
         private static void LoadScene(string[] args)
         {
@@ -310,6 +313,119 @@ namespace GameManagers
                 }
             }
         }
+
+        [CommandAttribute("spawn", "/spawn [PrefabName][Tag][Position][Rotation][Scale]: Spawns a custom prefab into the map with the given attributes.")]
+        private static void SpawnCustomPrefab(string[] args)
+        {
+            if (CheckMC())
+            {
+                if (args.Length != 6)
+                {
+                    AddLine("Invalid arguments passed! Correct usage: /spawn [PrefabName][Tag][Position][Rotation][Scale]", ChatTextColor.Error);
+                    AddLine("Example usage: /spawn Test test_prefab_1 (-16,2,-500) (1,1,1,1) (1,1,1)", ChatTextColor.Error);
+                    return;
+                }
+
+                string prefab_name = $"{ResourcePaths.Expedition}/{args[1]}";
+                string prefab_tag = $"gpf_{args[2]}";
+
+                if (!TryParseVector3(args[3], out Vector3 prefab_position))
+                    return;
+
+                if (!TryParseQuaternion(args[4], out Quaternion prefab_rotation))
+                    return;
+                
+                if (!TryParseVector3(args[5], out Vector3 prefab_scale))
+                    return;
+                
+                GameObject go = PhotonNetwork.Instantiate(prefab_name, prefab_position, prefab_rotation);
+
+                if (!go)
+                {
+                    AddLine("Instantiation of the prefab failed! Check if it's included in the 'Resources' folder and that it has a PhotonView component attached to it.", ChatTextColor.Error);
+                    return;
+                }
+
+                go.name = prefab_tag;
+                go.transform.localScale = prefab_scale;
+            }
+        }
+
+        [CommandAttribute("kill", "/kill [Tag]: Despawns all prefabs with the given tag.")]
+        private static void KillCustomPrefab(string[] args)
+        {
+            if (CheckMC())
+            {
+                if (args.Length != 2)
+                {
+                    AddLine("Invalid argument passed!", ChatTextColor.Error);
+                    AddLine("Example usage: /kill test_prefab");
+                    return;
+                }
+
+                GameObject[] objects = FindObjectsByType<GameObject>(FindObjectsSortMode.None)
+                    .Where(t => t.name == $"gpf_{args[1]}")
+                    .Select(t => t)
+                    .ToArray();
+                
+                for (int i = 0; i < objects.Length; ++i)
+                {
+                    PhotonNetwork.Destroy(objects[i]);
+                }
+            }
+        }
+
+        private static bool TryParseVector3(string input, out Vector3 result)
+        {
+            try 
+            {
+                string[] splitInput = input.Trim('(', ')').Split(',');
+                if (splitInput.Length != 3)
+                {
+                    AddLine($"Vector3 argument has invalid format: {input}", ChatTextColor.Error);
+                    AddLine("Example valid format: (1,1,1)");
+                    result = Vector3.zero;
+                    return false;
+                }
+
+                float[] values = splitInput.Select(float.Parse).ToArray();
+                result = new Vector3(values[0], values[1], values[2]);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AddLine($"Failed to parse position: {ex.Message}", ChatTextColor.Error);
+                result = Vector3.zero;
+                return false;
+            }
+        }
+
+        private static bool TryParseQuaternion(string input, out Quaternion result)
+        {
+            try
+            {
+                string[] splitInput = input.Trim('(', ')').Split(',');
+                if (splitInput.Length != 4)
+                {
+                    AddLine($"Quaternion argument has invalid format: ${input}", ChatTextColor.Error);
+                    AddLine("Example valid format: (1,1,1,1)");
+                    result = Quaternion.identity;
+                    return false;
+                }
+
+                float[] values = splitInput.Select(float.Parse).ToArray();
+                result = new Quaternion(values[0], values[1], values[2], values[3]);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                AddLine($"Failed to parse position: {ex.Message}", ChatTextColor.Error);
+                result = Quaternion.identity;
+                return false;
+            }
+        }
+
+        #endregion Expedition Mod Commands
 
         [CommandAttribute("restart", "/restart: Restarts the game.", Alias = "r")]
         private static void Restart(string[] args)

--- a/Assets/Scripts/Utility/ResourcePaths.cs
+++ b/Assets/Scripts/Utility/ResourcePaths.cs
@@ -17,5 +17,6 @@ namespace Utility
         public static string Spawnables = "Spawnables/Prefabs";
         public static string Projectiles = "Projectiles/Prefabs";
         public static string Weather = "Weather";
+        public static string Expedition = "GamePfs";
     }
 }


### PR DESCRIPTION
Added prefab spawning & despawning.

**Rules**
- Prefabs must be in /Assets/Resources/GamePfs.
- Prefabs must have a PhotonView component attached to them.
- Spawn command runs with `/spawn [PrefabName][Tag][Position][Rotation][Scale]`
- Kill command runs with `/kill [Tag]`
- Multiple prefabs with the same [Tag] can be instantiated.
- If there exists multiple game objects with the tag [Tag], all of them will be destroyed with the `/kill` command.

Example Spawn Command: 
```
/spawn Test test_prefab_1 (-16,2,-500) (0,0,0,1) (1,1,1)
```

Example Kill Command: 
```
/kill test_prefab_1
```