### PR TITLE
Fix Specials Reset On Change

### DIFF
--- a/Assets/Scripts/Characters/Human/Human.cs
+++ b/Assets/Scripts/Characters/Human/Human.cs
@@ -779,17 +779,24 @@ namespace Characters
             var character = (BaseShifter)_inGameManager.CurrentCharacter;
             character.PreviousHumanGas = Stats.CurrentGas;
             character.PreviousHumanWeapon = Weapon;
+            character.PreviousAbilityCooldowns = GetComponent<Veteran>().AbilityCooldowns;
             PhotonNetwork.LocalPlayer.SetCustomProperty(PlayerProperty.CharacterViewId, character.Cache.PhotonView.ViewID);
             PhotonNetwork.Destroy(gameObject);
         }
 
-        public IEnumerator WaitAndTransformFromShifter(float previousHumanGas, BaseUseable previousHumanWeapon)
+        public IEnumerator WaitAndTransformFromShifter(float previousHumanGas, BaseUseable previousHumanWeapon, Dictionary<string, float> previousAbilityCooldowns)
         {
             while (!FinishSetup)
             {
                 yield return null;
             }
             Stats.CurrentGas = previousHumanGas;
+
+            Veteran veteran = GetComponent<Veteran>();
+            InGameCharacterSettings _s = SettingsManager.InGameCharacterSettings;
+            veteran.AbilityCooldowns = previousAbilityCooldowns;
+            veteran.SetAllSpecials(_s.Special.Value, _s.Special_2.Value, _s.Special_3.Value, true);
+
             if (previousHumanWeapon is BladeWeapon)
             {
                 BladeWeapon previousBlade = (BladeWeapon)previousHumanWeapon;

--- a/Assets/Scripts/Characters/Human/Specials/EscapeSpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/EscapeSpecial.cs
@@ -4,14 +4,12 @@ using UnityEngine;
 
 namespace Characters
 {
-    class EscapeSpecial : ExtendedUseable
+    class EscapeSpecial : ResetSpecial
     {
         protected override float ActiveTime => 0.64f;
 
-        public EscapeSpecial(BaseCharacter owner) : base(owner)
+        public EscapeSpecial(BaseCharacter owner) : base(owner, "Escape", 1800f)
         {
-            Cooldown = 1800f; // changed by Ata, 5 Mar 25
-            _lastUseTime = Time.time - Cooldown;
         }
 
         public override bool CanUse()
@@ -35,6 +33,11 @@ namespace Characters
                 human.SpecialActionState(0.5f);
                 human.Cache.Rigidbody.velocity = Vector3.up * 30f;
             }
+        }
+
+        public override void SetInitialCooldown()
+        {
+            _lastUseTime = Time.time - Cooldown;
         }
     }
 }

--- a/Assets/Scripts/Characters/Human/Specials/ResetSpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/ResetSpecial.cs
@@ -1,0 +1,56 @@
+using ExitGames.Client.Photon.StructWrapping;
+using Settings;
+using UnityEngine;
+
+namespace Characters
+{
+    /// <summary>
+    /// A useable that is protected from abuse by endless resets and performs logic over extended update frames.
+    /// </summary>
+    abstract class ResetSpecial : ExtendedUseable
+    {
+        public string SpecialName;
+
+        public ResetSpecial(BaseCharacter owner, string specialName, float coolDown) : base(owner)
+        {
+            SpecialName = specialName;
+            Cooldown = coolDown;
+
+            if (SpecialName != null && _owner.GetComponent<Veteran>().AbilityCooldowns.TryGetValue(SpecialName, out float _cooldown)) {
+                if (_cooldown > 0f) {
+                    SetCooldownLeft(_cooldown);
+                } else if (_cooldown <= 0f) {
+                    RemoveFromDictionary();
+                    SetInitialCooldown();
+                }
+            } else {
+                SetInitialCooldown();
+            }
+        }
+
+        protected override void OnUse()
+        {
+            base.OnUse();
+            AddToDictionary();
+        }
+        protected void AddToDictionary()
+        {
+            if (_owner.GetComponent<Veteran>().AbilityCooldowns.ContainsKey(SpecialName))
+               return;
+
+            _owner.GetComponent<Veteran>().AbilityCooldowns.Add(SpecialName, GetCooldownLeft());
+        }
+        
+        protected void RemoveFromDictionary()
+        {
+            if (!_owner.GetComponent<Veteran>().AbilityCooldowns.ContainsKey(SpecialName))
+                return;
+            
+            _owner.GetComponent<Veteran>().AbilityCooldowns.Remove(SpecialName);
+        }
+
+        public virtual void SetInitialCooldown()
+        {
+        }
+    }
+}

--- a/Assets/Scripts/Characters/Human/Specials/ResetSpecial.cs.meta
+++ b/Assets/Scripts/Characters/Human/Specials/ResetSpecial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a19d12c38e5eb9e43a91a4468d6e8f21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Characters/Human/Specials/ShifterTransformSpecial.cs
+++ b/Assets/Scripts/Characters/Human/Specials/ShifterTransformSpecial.cs
@@ -3,17 +3,15 @@ using UnityEngine;
 
 namespace Characters
 {
-    class ShifterTransformSpecial : ExtendedUseable
+    class ShifterTransformSpecial : ResetSpecial
     {
         public float LiveTime = 60f;
         protected string _shifter;
         protected override float ActiveTime => 0.8f;
 
-        public ShifterTransformSpecial(BaseCharacter owner, string shifter): base(owner)
+        public ShifterTransformSpecial(BaseCharacter owner, string shifter): base(owner, shifter, 60f)
         {
-            Cooldown = 60f;
             _shifter = shifter;
-            SetCooldownLeft(Cooldown);
         }
 
         protected override void Activate()
@@ -26,6 +24,11 @@ namespace Characters
             var human = (Human)_owner;
             if (!human.Dead)
                 human.TransformShifter(_shifter, LiveTime);
+        }
+
+        public override void SetInitialCooldown()
+        {
+            SetCooldownLeft(Cooldown);
         }
     }
 }

--- a/Assets/Scripts/Characters/Shifters/BaseShifter.cs
+++ b/Assets/Scripts/Characters/Shifters/BaseShifter.cs
@@ -13,6 +13,7 @@ using System.Collections;
 using CustomLogic;
 using CustomSkins;
 using Photon.Pun;
+using System.Collections.Generic;
 
 namespace Characters
 {
@@ -30,6 +31,7 @@ namespace Characters
         public bool TransformingToHuman;
         public float PreviousHumanGas;
         public BaseUseable PreviousHumanWeapon;
+        public Dictionary<string, float> PreviousAbilityCooldowns;
         public float DeathAnimationLength = 2f;
         protected BaseCustomSkinLoader _customSkinLoader;
 
@@ -90,7 +92,7 @@ namespace Characters
             yield return new WaitForSeconds(2f);
             _inGameManager.SpawnPlayerAt(false, BaseTitanCache.Neck.position, BaseTitanCache.Neck.rotation.eulerAngles.y);
             Human currentCharacter = ((Human)_inGameManager.CurrentCharacter);
-            currentCharacter.StartCoroutine(currentCharacter.WaitAndTransformFromShifter(PreviousHumanGas, PreviousHumanWeapon));
+            currentCharacter.StartCoroutine(currentCharacter.WaitAndTransformFromShifter(PreviousHumanGas, PreviousHumanWeapon, PreviousAbilityCooldowns));
         }
 
         protected override IEnumerator WaitAndDie()

--- a/Assets/Scripts/Expedition/Roles/Veteran.cs
+++ b/Assets/Scripts/Expedition/Roles/Veteran.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using Characters;
 using Photon.Pun;
 using Settings;
@@ -9,6 +11,7 @@ class Veteran : MonoBehaviour
     private Human human;
     private VeteranManager _veteranManager;
     public bool isVeteranSet = false;
+    public Dictionary<string, float> AbilityCooldowns = new Dictionary<string, float> {};
     void Start()
     {
         _veteranManager = FindFirstObjectByType<VeteranManager>();
@@ -23,6 +26,14 @@ class Veteran : MonoBehaviour
     void Update()
     {
         SetupVeteran();
+
+        foreach (var key in AbilityCooldowns.Keys.ToList())
+        {
+            AbilityCooldowns[key] -= Time.deltaTime;
+
+            if (AbilityCooldowns[key] <= 0f)
+                AbilityCooldowns.Remove(key);
+        }
     }
 
     public void SetMyHuman(Human _human)
@@ -30,11 +41,22 @@ class Veteran : MonoBehaviour
         human = _human;
     }
 
-    public void SetAllSpecials(string special1, string special2, string special3)
+    public void SetAllSpecials(string special1, string special2, string special3, bool _setCooldowns = false)
     {
         human.Special = HumanSpecials.GetSpecialUseable(human, special1);
         human.Special_2 = HumanSpecials.GetSpecialUseable(human, special2);
         human.Special_3 = HumanSpecials.GetSpecialUseable(human, special3);
+        
+        if (_setCooldowns && human.Special is ResetSpecial && AbilityCooldowns.TryGetValue(((ResetSpecial)human.Special).SpecialName, out float _storedCooldown_1)) {
+            human.Special.SetCooldownLeft(_storedCooldown_1);
+        }
+        if (_setCooldowns && human.Special_2 is ResetSpecial && AbilityCooldowns.TryGetValue(((ResetSpecial)human.Special_2).SpecialName, out float _storedCooldown_2)) {
+            human.Special_2.SetCooldownLeft(_storedCooldown_2);
+        }
+        if (_setCooldowns && human.Special_3 is ResetSpecial && AbilityCooldowns.TryGetValue(((ResetSpecial)human.Special_3).SpecialName, out float _storedCooldown_3)) {
+            human.Special_3.SetCooldownLeft(_storedCooldown_3);
+        }
+
         human.SpecialsArray = new BaseUseable[] 
         {
             human.Special,

--- a/Assets/Scripts/UI/InGameMenu/CharacterHumanPanel.cs
+++ b/Assets/Scripts/UI/InGameMenu/CharacterHumanPanel.cs
@@ -45,6 +45,9 @@ namespace UI
             if (lastCharSettings.CharacterType.Value == PlayerCharacter.Human)
             {
                 charSettings.Special.Value = lastCharSettings.Special.Value;
+                charSettings.Special_2.Value = lastCharSettings.Special_2.Value;
+                charSettings.Special_3.Value = lastCharSettings.Special_3.Value;
+
                 charSettings.Costume.Value = lastCharSettings.Costume.Value;
                 charSettings.CustomSet.Value = lastCharSettings.CustomSet.Value;
                 charSettings.Loadout.Value = lastCharSettings.Loadout.Value;
@@ -154,6 +157,9 @@ namespace UI
             InGameCharacterSettings charSettings = SettingsManager.InGameCharacterSettings;
             InGameCharacterSettings lastCharSettings = SettingsManager.InGameSettings.LastCharacter;
             lastCharSettings.Special.Value = charSettings.Special.Value;
+            lastCharSettings.Special_2.Value = charSettings.Special_2.Value;
+            lastCharSettings.Special_3.Value = charSettings.Special_3.Value;
+
             lastCharSettings.Costume.Value = charSettings.Costume.Value;
             lastCharSettings.CustomSet.Value = charSettings.CustomSet.Value;
             lastCharSettings.Loadout.Value = charSettings.Loadout.Value;

--- a/Assets/Scripts/UI/InGameMenu/CharacterPopup.cs
+++ b/Assets/Scripts/UI/InGameMenu/CharacterPopup.cs
@@ -107,6 +107,8 @@ namespace UI
                 last.CustomSet.Value = current.CustomSet.Value;
                 last.Loadout.Value = current.Loadout.Value;
                 last.Special.Value = current.Special.Value;
+                last.Special_2.Value = current.Special_2.Value;
+                last.Special_3.Value = current.Special_3.Value;
                 SettingsManager.InGameSettings.Save();
             }
         }


### PR DESCRIPTION
Certain specials will be starting with their respective cooldowns that were active before specials were changed from the supply station.